### PR TITLE
make store options conform node_redis and enabling url option therefore

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -17,11 +17,7 @@ module.exports = function (opts) {
     store: {}
   }, opts)
 
-  var client = redis.createClient(
-    opts.store.port,
-    opts.store.host,
-    opts.store.options
-  )
+  var client = redis.createClient(opts.store)
   client.get = thunkify(client.get)
   client.set = thunkify(client.set)
   client.del = thunkify(client.del)


### PR DESCRIPTION
Hey, I see `url` option (important for heroku) available in Readme but it isn't passed in code. I propose to just leave redis initialisation as-is. host/port options will work this way too.
