### PR TITLE
extracted session retrieval and storing into separate method

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -23,6 +23,38 @@ class RedisSession {
     this.client.ttl = this.options.ttl ? (key) => this.client.expire(key, this.options.ttl) : () => undefined
   }
 
+  getSession (key) {
+    var session = {}
+    return this.client.getAsync(key)
+      .then((json) => {
+        if (json) {
+          try {
+            session = JSON.parse(json)
+            debug('session state', session)
+          } catch (error) {
+            debug('Parse session state failed', error)
+          }
+        }
+
+        return {
+          session,
+          saveSession: (session) => {
+            if (Object.keys(session).length === 0) {
+              debug('clear session')
+              return this.client.delAsync(key)
+            }
+
+            debug('save session', session)
+            return this.client.setAsync(key, JSON.stringify(session))
+              .then(() => {
+                debug('session ttl', session)
+                this.client.ttl(key)
+              })
+          }
+        }
+      })
+  }
+
   middleware () {
     return (ctx, next) => {
       const key = this.options.getSessionKey(ctx)
@@ -30,34 +62,15 @@ class RedisSession {
         return next()
       }
       debug('session key %s', key)
-      var session = {}
-      Object.defineProperty(ctx, this.options.property, {
-        get: function () { return session },
-        set: function (newValue) { session = Object.assign({}, newValue) }
+
+      return this.getSession(key).then(({ session, saveSession }) => {
+        Object.defineProperty(ctx, this.options.property, {
+          get: function () { return session },
+          set: function (newValue) { session = Object.assign({}, newValue) }
+        })
+        return next().then(() => { saveSession(session) })
       })
-      return this.client.getAsync(key)
-        .then((json) => {
-          if (json) {
-            try {
-              session = JSON.parse(json)
-              debug('session state', session)
-            } catch (error) {
-              debug('Parse session strate failed', error)
-            }
-          }
-          return next()
-        })
-        .then(() => {
-          if (Object.keys(session).length === 0) {
-            debug('clear session')
-            return this.client.delAsync(key)
-          }
-          debug('save session', session)
-          return this.client.setAsync(key, JSON.stringify(session))
-            .then(() => {
-              this.client.ttl(key)
-            })
-        })
+
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ $ npm install telegraf-session-redis
 ```
 
 ## Example
-  
+
 ```js
 const Telegraf = require('telegraf')
 const RedisSession = require('telegraf-session-redis')
@@ -38,11 +38,28 @@ telegraf.on('text', (ctx) => {
 telegraf.startPolling()
 ```
 
+When you have stored the session key beforehand, you can access a
+session without having access to a context object. This is useful when
+you perform OAUTH or something similar, when a REDIRECT_URI is called
+on your bot server.
+
+```js
+const redisSession = new RedisSession(/* ... */)
+
+redisSession.getSession(key).then({ session, saveSession } => {
+  console.log('Session', session)
+
+  // change and save the session
+  session.counter++
+  saveSession(session)
+})
+```
+
 ## API
 
 ### Options
 
-* `store`: 
+* `store`:
   * `host`: Redis host (default: *127.0.0.1*)
   * `port`: Redis port (default: *6379*)
   * `path`: Unix socket string
@@ -97,4 +114,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/test/session-test.js
+++ b/test/session-test.js
@@ -3,6 +3,21 @@ const should = require('should')
 const RedisSession = require('../lib/session')
 
 describe('Telegraf Session', function () {
+  it('should retrieve and save session', function(done) {
+    const redisSession = new RedisSession()
+    redisSession.getSession(({ session, saveSession }) => {
+      should.exist(session)
+      session.should.be.equal({})
+      session.foo = 42
+      return saveSession(session)
+    }).then(() => {
+      return redisSession.getSession(({ session }) => {
+        should.exist(session)
+        session.should.be.deepEqual({ foo: 42 })
+      })
+    }).then(() => done())
+  })
+
   it('should be defined', function (done) {
     const app = new Telegraf()
     const session = new RedisSession()


### PR DESCRIPTION
i want to access the redis client from outside a context. now i do not want to handle session retrieval and storing manually. i reused the default behavior and extracted it into a separate method. tests/ short readme entry added.
