### PR TITLE
Avoid overriding the inner middleware's result with an empty object

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -75,7 +75,7 @@ class RedisSession {
           get: function () { return session },
           set: function (newValue) { session = Object.assign({}, newValue) }
         })
-        return next().then(() => this.saveSession(key, session))
+        return next().then(middlewareData => this.saveSession(key, session).then(() => middlewareData))
       })
     }
   }


### PR DESCRIPTION
In the promise call chain, avoid returning as resolution data an empty object as done the `saveSession` method. 
Therefore, add closure to return the middleware resolution data after the save session promise completes.